### PR TITLE
Please use '--become' not '--become true'

### DIFF
--- a/mistral_ansible_actions.py
+++ b/mistral_ansible_actions.py
@@ -28,7 +28,7 @@ class AnsibleAction(base.Action):
             command.extend(['--user', self.remote_user])
 
         if self.become:
-            command.extend(['--become', self.become])
+            command.extend(['--become'])
 
         if self.become_user:
             command.extend(['--become-user', self.become_user])
@@ -60,7 +60,7 @@ class AnsiblePlaybookAction(base.Action):
             command.extend(['--user', self.remote_user])
 
         if self.become:
-            command.extend(['--become', self.become])
+            command.extend(['--become'])
 
         if self.become_user:
             command.extend(['--become-user', self.become_user])


### PR DESCRIPTION
Without this change Workflows using Ansible 2.1.0.0 and the Action
ansible reach State ERROR and output: <% task(test).result %> contains
"ERROR! Extranous options or arguments". The action ansible-playbook
produces "Stderr: u'ERROR! the playbook: True could not be found".
Root cause seems to be that the --become flag in Ansible should not
be passed an argument like true or false, as per the documentation:
http://docs.ansible.com/ansible/become.html#new-command-line-options.
This issue does not occur when "become: false" is in the Task because
the command is not extended in that case.