### PR TITLE
Please use --limit in place of --args for the ansible-playbook task

### DIFF
--- a/mistral_ansible_actions.py
+++ b/mistral_ansible_actions.py
@@ -54,7 +54,7 @@ class AnsiblePlaybookAction(base.Action):
         command = ['ansible-playbook', self.playbook]
 
         if self.limit_hosts:
-            command.extend(['--args', self.limit_hosts])
+            command.extend(['--limit', self.limit_hosts])
 
         if self.remote_user:
             command.extend(['--user', self.remote_user])


### PR DESCRIPTION
The limit_hosts option for the ansible-playbook action expands the command with '--args':

https://github.com/d0ugal/mistral-ansible-actions/blob/master/mistral_ansible_actions.py#L57

However, this does not seem to be a supported option:

[stack@undercloud ~]$ ansible-playbook --args foo
Usage: ansible-playbook playbook.yml

ansible-playbook: error: no such option: --args
[stack@undercloud ~]$

The intention behind the example, makes me think it should be the following instead:

[stack@undercloud ~]$ ansible-playbook --help | grep limit
-l SUBSET, --limit=SUBSET
further limit selected hosts to an additional pattern
[stack@undercloud ~]$

Tested this with ansible-playbook 2.2.1.0 and compared to man page:

https://linux.die.net/man/1/ansible-playbook