### PR TITLE
Add extra_vars support to ansible-playbook action

### DIFF
--- a/mistral_ansible_actions.py
+++ b/mistral_ansible_actions.py
@@ -41,13 +41,14 @@ class AnsibleAction(base.Action):
 class AnsiblePlaybookAction(base.Action):
 
     def __init__(self, playbook, limit_hosts=None, remote_user=None,
-                 become=None, become_user=None):
+                 become=None, become_user=None, extra_vars=None):
 
         self.playbook = playbook
         self.limit_hosts = limit_hosts
         self.remote_user = remote_user
         self.become = become
         self.become_user = become_user
+        self.extra_vars = extra_vars
 
     def run(self):
 
@@ -64,6 +65,9 @@ class AnsiblePlaybookAction(base.Action):
 
         if self.become_user:
             command.extend(['--become-user', self.become_user])
+
+        if self.extra_vars:
+            command.extend(['--extra-vars', self.extra_vars])
 
         stderr, stdout = processutils.execute(
             *command, log_errors=processutils.LogErrors.ALL)


### PR DESCRIPTION
The ansible-playbook command supports the '-e', or
'--extra-vars' argument to 'set additional variables
as key=value or YAML/JSON' to a playbook. This small
change adds this as a supported option.

This is a useful feature to add until the problem is solved
in general as per:

https://github.com/d0ugal/mistral-ansible-actions/issues/4